### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,6 +3,9 @@ name: .NET Core Desktop
 on:
   pull_request:
     branches: [ "main" ]
+
+permissions:
+  contents: read
     
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/atbu/Rockhopper/security/code-scanning/1](https://github.com/atbu/Rockhopper/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Based on the provided steps, the workflow primarily performs read operations (e.g., checking out code and restoring dependencies) and does not appear to require write permissions. Therefore, we will set `contents: read` as the minimal permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
